### PR TITLE
Update to classify egress correctly for billing.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
   "botocore",
   "pulsar-client",
   "click",
-  "eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@v0.1.10",
+  "eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@v0.1.11",
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,12 +10,12 @@ attrs==25.3.0
     #   referencing
 black==25.1.0
     # via eodhp-accounting-s3-usage (pyproject.toml)
-boto3==1.38.14
+boto3==1.38.16
     # via
     #   eodhp-accounting-s3-usage (pyproject.toml)
     #   eodhp-utils
     #   moto
-botocore==1.38.14
+botocore==1.38.16
     # via
     #   boto3
     #   eodhp-accounting-s3-usage (pyproject.toml)
@@ -47,11 +47,11 @@ deprecated==1.2.18
     #   opentelemetry-semantic-conventions
 distlib==0.3.9
     # via virtualenv
-eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@v0.1.10
+eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@v0.1.11
     # via eodhp-accounting-s3-usage (pyproject.toml)
 execnet==2.1.1
     # via pytest-xdist
-faker==37.1.0
+faker==37.3.0
     # via
     #   eodhp-accounting-s3-usage (pyproject.toml)
     #   eodhp-utils
@@ -126,11 +126,11 @@ platformdirs==4.3.8
     # via
     #   black
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
 pre-commit==4.2.0
     # via eodhp-accounting-s3-usage (pyproject.toml)
-pulsar-client==3.6.1
+pulsar-client==3.7.0
     # via
     #   eodhp-accounting-s3-usage (pyproject.toml)
     #   eodhp-utils
@@ -174,11 +174,11 @@ requests==2.32.3
     #   responses
 responses==0.25.7
     # via moto
-rpds-py==0.24.0
+rpds-py==0.25.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.11.9
+ruff==0.11.10
     # via eodhp-accounting-s3-usage (pyproject.toml)
 s3transfer==0.12.0
     # via boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,11 @@ attrs==25.3.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.38.14
+boto3==1.38.16
     # via
     #   eodhp-accounting-s3-usage (pyproject.toml)
     #   eodhp-utils
-botocore==1.38.14
+botocore==1.38.16
     # via
     #   boto3
     #   eodhp-accounting-s3-usage (pyproject.toml)
@@ -30,9 +30,9 @@ deprecated==1.2.18
     # via
     #   opentelemetry-api
     #   opentelemetry-semantic-conventions
-eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@v0.1.10
+eodhp-utils @ git+https://github.com/EO-DataHub/eodhp-utils@v0.1.11
     # via eodhp-accounting-s3-usage (pyproject.toml)
-faker==37.1.0
+faker==37.3.0
     # via eodhp-utils
 idna==3.10
     # via requests
@@ -70,7 +70,7 @@ opentelemetry-semantic-conventions==0.54b0
     #   opentelemetry-sdk
 packaging==25.0
     # via opentelemetry-instrumentation
-pulsar-client==3.6.1
+pulsar-client==3.7.0
     # via
     #   eodhp-accounting-s3-usage (pyproject.toml)
     #   eodhp-utils
@@ -86,7 +86,7 @@ referencing==0.36.2
     #   jsonschema-specifications
 requests==2.32.3
     # via eodhp-utils
-rpds-py==0.24.0
+rpds-py==0.25.0
     # via
     #   jsonschema
     #   referencing


### PR DESCRIPTION
Update eodhp-utils to a version which correctly classifies egress to private IPs.
